### PR TITLE
Remove `packfile` tag from the `packfile-sha256` fixture

### DIFF
--- a/fixtures.go
+++ b/fixtures.go
@@ -187,7 +187,7 @@ var fixtures = Fixtures{{
 	Tags:         []string{"packfile", "delta-before-base"},
 	PackfileHash: "90fedc00729b64ea0d0406db861be081cda25bbf",
 }, {
-	Tags:         []string{"packfile", "pack-sha256"},
+	Tags:         []string{"packfile-sha256"},
 	PackfileHash: "407497645643e18a7ba56c6132603f167fe9c51c00361ee0c81d74a8f55d0ee2",
 }}
 

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -40,7 +40,7 @@ func TestEmbeddedFiles(t *testing.T) {
 }
 
 func TestRevFiles(t *testing.T) {
-	f := ByTag("pack-sha256").One()
+	f := ByTag("packfile-sha256").One()
 
 	if f.Rev() == nil {
 		assert.Fail(t, "failed to get rev file")


### PR DESCRIPTION
In the future, new tags could be used to cover both formats. At this point in time, make a clear distinction to avoid backwards compatibility with users relying on the `packfile` tag.